### PR TITLE
Fix worker netty channel to actually retry a request if no ack is received

### DIFF
--- a/majordodo-core/src/main/java/majordodo/utils/TestUtils.java
+++ b/majordodo-core/src/main/java/majordodo/utils/TestUtils.java
@@ -30,7 +30,9 @@ public class TestUtils {
 
     public static void waitForCondition(Callable<Boolean> condition, Callable<Void> callback, int seconds) throws Exception {
         try {
-            while (seconds-- > 0) {
+            long _start = System.currentTimeMillis();
+            long millis = seconds * 1000L;
+            while (System.currentTimeMillis() - _start <= millis) {
                 if (condition.call()) {
                     return;
                 }
@@ -46,8 +48,7 @@ public class TestUtils {
             throw ee;
         }
 
-        throw new Exception(
-                "condition not met in time!");
+        throw new Exception("condition not met in time!");
     }
 
     public static Callable<Void> NOOP = () -> null;

--- a/majordodo-core/src/test/java/majordodo/task/NettyReplyDeadlineTest.java
+++ b/majordodo-core/src/test/java/majordodo/task/NettyReplyDeadlineTest.java
@@ -1,0 +1,115 @@
+package majordodo.task;
+
+import static org.junit.Assert.assertTrue;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import majordodo.clientfacade.AddTaskRequest;
+import majordodo.clientfacade.TaskStatusView;
+import majordodo.network.Message;
+import majordodo.network.netty.NettyBrokerLocator;
+import majordodo.utils.TestUtils;
+import majordodo.worker.WorkerCore;
+import majordodo.worker.WorkerCoreConfiguration;
+import majordodo.worker.WorkerStatusListener;
+import org.junit.Assert;
+import org.junit.Test;
+
+@BrokerTestUtils.StartBroker
+public class NettyReplyDeadlineTest extends BrokerTestUtils {
+
+    @Test
+    public void testWorkerRetryTaskFinished() throws Exception {
+        String workerId = "abc";
+        String taskParams = "param";
+
+        AtomicBoolean swallowTaskFinished = new AtomicBoolean(true);
+        AtomicLong taskFinishedReceived = new AtomicLong(0);
+        AtomicLong taskId = new AtomicLong(0);
+
+        broker.getAcceptor().setConnectionFactory((channel, broker1) -> {
+            BrokerSideConnection conn = new BrokerSideConnection() {
+                @Override
+                public void messageReceived(Message message) {
+                    if (message.type == Message.TYPE_TASK_FINISHED) {
+                        taskFinishedReceived.incrementAndGet();
+                        if (swallowTaskFinished.get()) {
+                            System.out.println("[DEBUG_LOG] Swallowing TASK_FINISHED for " + taskId.get());
+                            swallowTaskFinished.set(false);
+                            return;
+                        }
+                    }
+                    super.messageReceived(message);
+                }
+
+                @Override
+                public boolean validate() {
+                    return true;
+                }
+            };
+            conn.setBroker(broker1);
+            conn.setChannel(channel);
+            return conn;
+        });
+
+        try (NettyBrokerLocator locator = new NettyBrokerLocator(server.getHost(), server.getPort(), server.isSsl())) {
+            CountDownLatch connectedLatch = new CountDownLatch(1);
+            WorkerStatusListener listener = new WorkerStatusListener() {
+                @Override
+                public void connectionEvent(String event, WorkerCore core) {
+                    if (event.equals(WorkerStatusListener.EVENT_CONNECTED)) {
+                        connectedLatch.countDown();
+                    }
+                }
+            };
+
+            Map<String, Integer> tags = new HashMap<>();
+            tags.put(TASKTYPE_MYTYPE, 1);
+
+            WorkerCoreConfiguration config = new WorkerCoreConfiguration();
+            config.setWorkerId(workerId);
+            config.setMaxThreadsByTaskType(tags);
+            config.setGroups(Arrays.asList(group));
+            config.setMaxPendingFinishedTaskNotifications(1);
+            config.setMaxWaitPendingFinishedTaskNotifications(10000);
+            config.setMaxKeepAliveTime(1000);
+            config.setNetworkTimeout(1000); // reply deadline 1 second
+
+            try (WorkerCore worker = new WorkerCore(config, workerId, locator, listener)) {
+                worker.setExecutorFactory((String taskType, Map<String, Object> parameters) -> new majordodo.executors.TaskExecutor() {
+                    @Override
+                    public String executeTask(Map<String, Object> parameters) throws Exception {
+                        return "ok";
+                    }
+                });
+                worker.start();
+
+                assertTrue(connectedLatch.await(10, TimeUnit.SECONDS));
+
+                // send task
+                // swallow first task_finished
+                // process the second one (the retry)
+                // assert that task is finished on broker side and we received both task_finished messages
+
+                taskId.set(broker.getClient().submitTask(new AddTaskRequest(0, TASKTYPE_MYTYPE, userId, taskParams, 0, 0, 0, null, 0, null, null)).getTaskId());
+
+                TestUtils.waitForCondition(() -> {
+                    TaskStatusView task = broker.getClient().getTask(taskId.get());
+                    return task != null && task.getStatus() == Task.STATUS_RUNNING;
+                }, TestUtils.NOOP, 10);
+
+                TestUtils.waitForCondition(() -> {
+                    TaskStatusView task = broker.getClient().getTask(taskId.get());
+                    return task != null && task.getStatus() == Task.STATUS_FINISHED;
+                }, TestUtils.NOOP, 20);
+
+                Assert.assertEquals(2, taskFinishedReceived.get());
+            }
+
+        }
+    }
+}

--- a/majordodo-net/src/main/java/majordodo/network/netty/NettyChannel.java
+++ b/majordodo-net/src/main/java/majordodo/network/netty/NettyChannel.java
@@ -19,10 +19,6 @@
  */
 package majordodo.network.netty;
 
-import majordodo.network.Channel;
-import majordodo.network.Message;
-import majordodo.network.ReplyCallback;
-import majordodo.network.SendResultCallback;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -33,9 +29,16 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-
+import majordodo.network.Channel;
+import majordodo.network.Message;
+import majordodo.network.ReplyCallback;
+import majordodo.network.SendResultCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +59,8 @@ public class NettyChannel extends Channel {
     private final Map<String, Long> pendingReplyMessagesDeadline = new ConcurrentHashMap<>();
     private final ExecutorService callbackexecutor;
     private final NettyConnector connector;
+    private final ScheduledExecutorService timer;
+    private ScheduledFuture<?> timerTask;
     private boolean ioErrors = false;
     private final long id = idGenerator.incrementAndGet();
     private final boolean disconnectOnReplyTimeout;
@@ -71,6 +76,12 @@ public class NettyChannel extends Channel {
         this.callbackexecutor = callbackexecutor;
         this.connector = connector;
         this.disconnectOnReplyTimeout = (connector == null); // only server-side
+        this.timer = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "dodo-netty-reply-deadlines-channel" + id);
+            t.setDaemon(true);
+            return t;
+        });
+        this.timerTask = this.timer.scheduleAtFixedRate(this::processPendingReplyMessagesDeadline, 1000, 1000, TimeUnit.MILLISECONDS);
     }
 
     public void messageReceived(Message message) {
@@ -221,6 +232,12 @@ public class NettyChannel extends Channel {
             return;
         }
         closed = true;
+        if (timerTask != null) {
+            timerTask.cancel(false);
+        }
+        if (timer != null) {
+            timer.shutdown();
+        }
         LOGGER.error(this + ": closing");
         String socketDescription = socket + "";
         if (socket != null) {


### PR DESCRIPTION
In production we sometimes found a task in `running` state (broker side) with no actual thread worker side. These "orphaned" task would cause delays because they would lock the assigned majordodo `slot`.

I looked into It and in the end I realized that in the `NettyChannel` we had the logic to retry requests if no reply was received before a deadline (see `pendingReplyMessagesDeadline`), but It was never executed.

I added 2 daemon thread (1 for the broker side and 1 for the worker side) that periodically invoke the `pendingReplyMessagesDeadline` of open channels.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
